### PR TITLE
Fix TARGET_OS_SIMULATOR not found

### DIFF
--- a/ios/Classes/SwiftFlutterMutePlugin.swift
+++ b/ios/Classes/SwiftFlutterMutePlugin.swift
@@ -10,7 +10,11 @@ public class SwiftFlutterMutePlugin: NSObject, FlutterPlugin {
     }
     
     var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
     }
     
   public static func register(with registrar: FlutterPluginRegistrar) {


### PR DESCRIPTION
Resolves #4

Context: https://stackoverflow.com/a/48871406/7829326
Apparently TARGET_OS_SIMULATOR is C only